### PR TITLE
New config: labels and colors + differentiate platforms

### DIFF
--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 // eslint-disable-next-line import/no-named-as-default
 import Benchmark from '../views/Benchmark';
-import CONFIG from '../config';
+import { CONFIG } from '../config';
 import './metricsGraphics.css';
 
 export default () => (

--- a/src/App/metricsGraphics.css
+++ b/src/App/metricsGraphics.css
@@ -1,40 +1,7 @@
-.chrome-color {
-  background-color: #ffcd02;
-}
-.firefox-color {
-  background-color: #e55525;
-}
-
 /* Metrics graphics lines */
 path.mg-line1 {
   stroke-width: 2;
 }
-.mg-area1-color {
-  fill: #e55525;
-}
-.mg-line1-color {
-  stroke: #e55525;
-}
-.mg-hover-line1-color {
-  fill: #e55525;
-}
-.mg-line1-legend-color {
-  color: #e55525;
-  fill: #e55525;
-}
 path.mg-line2 {
   stroke-width: 2;
-}
-.mg-area2-color {
-  fill: #ffcd02;
-}
-.mg-line2-color {
-  stroke: #ffcd02;
-}
-.mg-hover-line2-color {
-  fill: #ffcd02;
-}
-.mg-line2-legend-color {
-  color: #ffcd02;
-  fill: #ffcd02;
 }

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Picker from '../../components/Picker';
-import CONFIG from '../../config';
+import { BENCHMARKS, CONFIG } from '../../config';
 
 const styles = () => ({
   root: {
@@ -34,10 +34,10 @@ const Header = ({
       onSelection={onChange}
       selectedValue={benchmark}
       options={
-        Object.keys(CONFIG.platforms[platform].benchmarks).reduce((res, benchmarkKey) => {
+        CONFIG.platforms[platform].benchmarks.reduce((res, benchmarkKey) => {
           res.push({
             value: benchmarkKey,
-            label: CONFIG.platforms[platform].benchmarks[benchmarkKey].label,
+            label: BENCHMARKS[benchmarkKey].label,
           });
           return res;
         }, [])

--- a/src/config.js
+++ b/src/config.js
@@ -1,33 +1,107 @@
-const RAPTOR_OPT_OPTIONS = { frameworkId: 10, buildType: 'opt' };
+const RAPTOR_FRAMEWORK_ID = 10;
 
-const BENCHMARKS = {
+export const BENCHMARKS = {
   'motionmark-animometer': {
-    compare: ['raptor-motionmark-animometer-firefox', 'raptor-motionmark-animometer-chrome'],
+    compare: [
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-motionmark-animometer-firefox',
+        buildType: 'opt',
+      },
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-motionmark-animometer-chrome',
+        buildType: 'opt',
+      },
+    ],
     label: 'MotionMark Animometer',
   },
   'motionmark-htmlsuite': {
-    compare: ['raptor-motionmark-htmlsuite-firefox', 'raptor-motionmark-htmlsuite-chrome'],
+    compare: [
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-motionmark-htmlsuite-firefox',
+        buildType: 'opt',
+      },
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-motionmark-htmlsuite-chrome',
+        buildType: 'opt',
+      },
+    ],
     label: 'MotionMark HtmlSuite',
   },
   speedometer: {
-    compare: ['raptor-speedometer-firefox', 'raptor-speedometer-chrome'],
+    compare: [
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-speedometer-firefox',
+        buildType: 'opt',
+      },
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-speedometer-chrome',
+        buildType: 'opt',
+      },
+    ],
     label: 'Speedometer',
   },
   stylebench: {
-    compare: ['raptor-stylebench-firefox', 'raptor-stylebench-chrome'],
+    compare: [
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-stylebench-firefox',
+        buildType: 'opt',
+      },
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-stylebench-chrome',
+        buildType: 'opt',
+      },
+    ],
     label: 'StyleBench',
   },
   sunspider: {
-    compare: ['raptor-sunspider-firefox', 'raptor-sunspider-chrome'],
+    compare: [
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-sunspider-firefox',
+        buildType: 'opt',
+      },
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-sunspider-chrome',
+        buildType: 'opt',
+      },
+    ],
     label: 'SunSpider',
   },
   webaudio: {
-    compare: ['raptor-webaudio-firefox', 'raptor-webaudio-chrome'],
+    compare: [
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-webaudio-firefox',
+        buildType: 'opt',
+      },
+      {
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: 'raptor-webaudio-chrome',
+        buildType: 'opt',
+      },
+    ],
     label: 'WebAudio',
   },
 };
 
-const CONFIG = {
+const DEFAULT_SUITES = [
+  'motionmark-animometer',
+  'motionmark-htmlsuite',
+  'speedometer',
+  'stylebench',
+  'webaudio',
+];
+
+export const CONFIG = {
   default: {
     landingPath: 'win10/motionmark-animometer',
   },
@@ -35,28 +109,22 @@ const CONFIG = {
     linux64: {
       label: 'Linux 64bit',
       platform: 'linux64',
-      benchmarks: BENCHMARKS,
-      ...RAPTOR_OPT_OPTIONS,
+      benchmarks: DEFAULT_SUITES,
     },
     mac: {
       label: 'Mac OS X',
       platform: 'osx-10-10',
-      benchmarks: BENCHMARKS,
-      ...RAPTOR_OPT_OPTIONS,
+      benchmarks: DEFAULT_SUITES,
     },
     win7: {
       label: 'Windows 7 32bit',
       platform: 'windows7-32',
-      benchmarks: BENCHMARKS,
-      ...RAPTOR_OPT_OPTIONS,
+      benchmarks: DEFAULT_SUITES,
     },
     win10: {
       label: 'Windows 10 64bit',
       platform: 'windows10-64',
-      benchmarks: BENCHMARKS,
-      ...RAPTOR_OPT_OPTIONS,
+      benchmarks: DEFAULT_SUITES,
     },
   },
 };
-
-export default CONFIG;

--- a/src/config.js
+++ b/src/config.js
@@ -104,6 +104,7 @@ const DEFAULT_SUITES = [
 export const CONFIG = {
   default: {
     landingPath: 'win10/motionmark-animometer',
+    colors: ['#e55525', '#ffcd02'],
   },
   platforms: {
     linux64: {

--- a/src/config.js
+++ b/src/config.js
@@ -105,6 +105,7 @@ export const CONFIG = {
   default: {
     landingPath: 'win10/motionmark-animometer',
     colors: ['#e55525', '#ffcd02'],
+    labels: ['Firefox', 'Chrome'],
   },
   platforms: {
     linux64: {

--- a/src/views/Benchmark/index.jsx
+++ b/src/views/Benchmark/index.jsx
@@ -4,7 +4,7 @@ import { curveLinear } from 'd3';
 import { subbenchmarksData } from '@mozilla-frontend-infra/perf-goggles';
 import { withRouter } from 'react-router-dom';
 import Header from '../../components/Header';
-import CONFIG from '../../config';
+import { BENCHMARKS, CONFIG } from '../../config';
 import prepareData from '../../utils/prepareData';
 import './benchmark.css';
 
@@ -55,21 +55,20 @@ export class Benchmark extends Component {
 
   async fetchData(platform, benchmark) {
     const allData = {};
-    const platformConfig = CONFIG.platforms[platform];
-    const benchmarksToCompare = platformConfig.benchmarks[benchmark].compare;
-    await Promise.all(benchmarksToCompare.map(async (benchmarkKey) => {
-      allData[benchmarkKey] = await subbenchmarksData(
-        platformConfig.frameworkId,
-        platformConfig.platform,
-        benchmarkKey,
-        platformConfig.buildType,
-      );
-    }));
+    await Promise.all(BENCHMARKS[benchmark].compare
+      .map(async (benchmarkOptions) => {
+        allData[benchmarkOptions.suite] = await subbenchmarksData(
+          benchmarkOptions.frameworkId,
+          CONFIG.platforms[platform].platform,
+          benchmarkOptions.suite,
+          benchmarkOptions.buildType,
+        );
+      }));
     this.setState({ benchmarkData: prepareData(allData) });
   }
 
   render() {
-    const { benchmark, benchmarkData, platform } = this.state;
+    const { benchmark, benchmarkData } = this.state;
 
     return (
       <div>
@@ -77,7 +76,7 @@ export class Benchmark extends Component {
         {benchmarkData && Object.keys(benchmarkData).length > 0 &&
           <div>
             <div>
-              <h3>{CONFIG.platforms[platform].benchmarks[benchmark].label}</h3>
+              <h3>{BENCHMARKS[benchmark].label}</h3>
               {Object.entries(benchmarkData.benchmark.urls).map((entry) => {
                 const browserKey = entry[0];
                 const url = entry[1];

--- a/src/views/Benchmark/index.jsx
+++ b/src/views/Benchmark/index.jsx
@@ -69,6 +69,9 @@ export class Benchmark extends Component {
 
   render() {
     const { benchmark, benchmarkData } = this.state;
+    const colors = BENCHMARKS[benchmark].colors
+      ? BENCHMARKS[benchmark].colors
+      : CONFIG.default.colors;
 
     return (
       <div>
@@ -77,14 +80,13 @@ export class Benchmark extends Component {
           <div>
             <div>
               <h3>{BENCHMARKS[benchmark].label}</h3>
-              {Object.entries(benchmarkData.benchmark.urls).map((entry) => {
+              {Object.entries(benchmarkData.benchmark.urls).map((entry, index) => {
                 const browserKey = entry[0];
                 const url = entry[1];
-                const classname = `legend ${browserKey === 'firefox' ? 'firefox-color' : 'chrome-color'}`;
                 const upperBrowser = browserKey.replace(/^\w/, c => c.toUpperCase());
                 return (
                   <div key={url}>
-                    <span className={classname} />
+                    <span className="legend" style={{ backgroundColor: colors[index] }} />
                     <span>{upperBrowser}:</span>
                     <a key={url} href={url} target="_blank" rel="noopener noreferrer">all subbenchmarks</a>
                   </div>
@@ -106,6 +108,7 @@ export class Benchmark extends Component {
                   full_width
                   right="60"
                   legend={['Firefox', 'Chrome']}
+                  colors={colors}
                   aggregate_rollover
                   interpolate={curveLinear}
                 />

--- a/src/views/Benchmark/index.jsx
+++ b/src/views/Benchmark/index.jsx
@@ -72,6 +72,9 @@ export class Benchmark extends Component {
     const colors = BENCHMARKS[benchmark].colors
       ? BENCHMARKS[benchmark].colors
       : CONFIG.default.colors;
+    const labels = BENCHMARKS[benchmark].labels
+      ? BENCHMARKS[benchmark].labels
+      : CONFIG.default.labels;
 
     return (
       <div>
@@ -81,13 +84,11 @@ export class Benchmark extends Component {
             <div>
               <h3>{BENCHMARKS[benchmark].label}</h3>
               {Object.entries(benchmarkData.benchmark.urls).map((entry, index) => {
-                const browserKey = entry[0];
                 const url = entry[1];
-                const upperBrowser = browserKey.replace(/^\w/, c => c.toUpperCase());
                 return (
                   <div key={url}>
                     <span className="legend" style={{ backgroundColor: colors[index] }} />
-                    <span>{upperBrowser}:</span>
+                    <span>{labels[index]}:</span>
                     <a key={url} href={url} target="_blank" rel="noopener noreferrer">all subbenchmarks</a>
                   </div>
                 );
@@ -106,8 +107,8 @@ export class Benchmark extends Component {
                   y_accessor="value"
                   min_y_from_data
                   full_width
-                  right="60"
-                  legend={['Firefox', 'Chrome']}
+                  right="90"
+                  legend={labels}
                   colors={colors}
                   aggregate_rollover
                   interpolate={curveLinear}


### PR DESCRIPTION
This PR enhanches the configuration file with these features:
* Support having different sets of benchmarks per platform
* Define default labels for graphs + method to override per benchmark
* Define default colors for graphs + method to override per benchmark