### PR TITLE
Issue #30 - Netlify not routing properly

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
We added routing for the app bb3ba3f38c40242fa15c21fce5fcfe16f178687e,
however, it only works locally because we did not configure Netlify to
do the same.