### PR TITLE
Issue #60 - Calculate Y labels on lower_is_better value from Treeherder

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -91,7 +91,6 @@ export const BENCHMARKS = {
       },
     },
     label: 'Speedometer',
-    scaleLabel: 'Score',
   },
   stylebench: {
     compare: {
@@ -168,7 +167,6 @@ export const BENCHMARKS = {
       },
     },
     label: 'Unity WebGL',
-    scaleLabel: 'Score',
   },
   'wasm-misc': {
     compare: {
@@ -277,7 +275,6 @@ export const BENCHMARKS = {
     },
     labels: ['SpiderMonkey', 'Chrome v8'],
     label: 'Web Tooling (JS shell)',
-    scaleLabel: 'Score',
   },
 };
 

--- a/src/utils/prepareData.js
+++ b/src/utils/prepareData.js
@@ -46,10 +46,13 @@ const chartJsOptions = (reverse, scaleLabel) => ({
 });
 
 const generateChartJsOptions = (configUID, meta) => {
-  const reversed = (meta.lower_is_better === false);
-  const scaleLabel = (BENCHMARKS[configUID].scaleLabel)
-    ? BENCHMARKS[configUID].scaleLabel : 'Execution time (ms)';
-  return chartJsOptions(reversed, scaleLabel);
+  const higherIsBetter = (meta.lower_is_better === false);
+  const reversed = higherIsBetter;
+  let yLabel = higherIsBetter ? 'Score' : 'Execution time (ms)';
+  if (BENCHMARKS[configUID].scaleLabel) {
+    yLabel = BENCHMARKS[configUID].scaleLabel;
+  }
+  return chartJsOptions(reversed, yLabel);
 };
 
 // This function overlays data from different browsers

--- a/test/mocks/linux64/preparedData.json
+++ b/test/mocks/linux64/preparedData.json
@@ -953,7 +953,7 @@
               },
               "scaleLabel": {
                 "display": true,
-                "labelString": "Execution time (ms)"
+                "labelString": "Score"
               }
             }
           ]
@@ -1071,7 +1071,7 @@
               },
               "scaleLabel": {
                 "display": true,
-                "labelString": "Execution time (ms)"
+                "labelString": "Score"
               }
             }
           ]
@@ -1181,7 +1181,7 @@
               },
               "scaleLabel": {
                 "display": true,
-                "labelString": "Execution time (ms)"
+                "labelString": "Score"
               }
             }
           ]
@@ -1425,7 +1425,7 @@
               },
               "scaleLabel": {
                 "display": true,
-                "labelString": "Score"
+                "labelString": "Execution time (ms)"
               }
             }
           ]


### PR DESCRIPTION
This change affects the following benchmarks:

Execution time -> Score:

* MotionMark Animometer
* MotionMark HtmlSuite
* StyleBench

Score -> Execution time

* Web Tooling (JS shell)