### PR TITLE
Fixes#68 Added icon for links

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^3.0.2",
-    "@material-ui/icons":"3.0.1",
+    "@material-ui/icons": "^3.0.1",
     "@mozilla-frontend-infra/perf-goggles": "^1.3.0",
     "chart.js": "^2.7.2",
     "prop-types": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^3.0.2",
+    "@material-ui/icons":"3.0.1",
     "@mozilla-frontend-infra/perf-goggles": "^1.3.0",
     "chart.js": "^2.7.2",
     "prop-types": "^15.6.2",

--- a/src/components/Graphs/index.jsx
+++ b/src/components/Graphs/index.jsx
@@ -1,8 +1,8 @@
-import Link from '@material-ui/icons/Link';
+import LinkIcon from '@material-ui/icons/Link';
+import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import Legend from '../../components/Legend';
 import ChartJSWrapper from '../../components/ChartJSWrapper';
-
 
 const sortOverviewFirst = (a, b) => {
   if (a.includes('overview') || b.includes('overview')) {
@@ -11,13 +11,14 @@ const sortOverviewFirst = (a, b) => {
   return (a <= b ? -1 : 1);
 };
 
-const inlineBlock = {
-  display: 'inline-block',
-  margin: '10px',
+const styles = {
+  benchmarkTitle: {
+    display: 'inline-block',
+    margin: '10px',
+  },
 };
 
-
-const Graphs = ({ benchmarkData, overviewMode }) => (
+const Graphs = ({ classes, benchmarkData, overviewMode }) => (
   <div>
     {!overviewMode &&
       Object.values(benchmarkData.topLabelsConfig).map(({
@@ -42,20 +43,20 @@ const Graphs = ({ benchmarkData, overviewMode }) => (
         chartJsData, chartJsOptions, jointUrl, title,
       }) => (
         <div key={title}>
-          <h2 style={inlineBlock}>{title}</h2>
-          <div style={inlineBlock}>
-            <a href={jointUrl} target="_blank" rel="noopener noreferrer"><Link /></a>
+          <h2 className={classes.benchmarkTitle}>{title}</h2>
+          <div className={classes.benchmarkTitle}>
+            <a href={jointUrl} target="_blank" rel="noopener noreferrer"><LinkIcon /></a>
           </div>
           <ChartJSWrapper chartJsData={chartJsData} chartJsOptions={chartJsOptions} />
-
         </div>
       ))}
   </div>
 );
 
 Graphs.propTypes = {
+  classes: PropTypes.shape({}).isRequired,
   benchmarkData: PropTypes.shape({}).isRequired,
   overviewMode: PropTypes.bool.isRequired,
 };
 
-export default Graphs;
+export default withStyles(styles)(Graphs);

--- a/src/components/Graphs/index.jsx
+++ b/src/components/Graphs/index.jsx
@@ -12,8 +12,8 @@ const sortOverviewFirst = (a, b) => {
 };
 
 const inlineBlock = {
- display: 'inline-block',
- margin: '10px'
+  display: 'inline-block',
+  margin: '10px',
 };
 
 
@@ -44,7 +44,7 @@ const Graphs = ({ benchmarkData, overviewMode }) => (
         <div key={title}>
           <h2 style={inlineBlock}>{title}</h2>
           <div style={inlineBlock}>
-          <a href={jointUrl} target="_blank" rel="noopener noreferrer"><Link/></a>
+            <a href={jointUrl} target="_blank" rel="noopener noreferrer"><Link /></a>
           </div>
           <ChartJSWrapper chartJsData={chartJsData} chartJsOptions={chartJsOptions} />
 

--- a/src/components/Graphs/index.jsx
+++ b/src/components/Graphs/index.jsx
@@ -1,6 +1,8 @@
+import Link from '@material-ui/icons/Link';
 import PropTypes from 'prop-types';
 import Legend from '../../components/Legend';
 import ChartJSWrapper from '../../components/ChartJSWrapper';
+
 
 const sortOverviewFirst = (a, b) => {
   if (a.includes('overview') || b.includes('overview')) {
@@ -8,6 +10,12 @@ const sortOverviewFirst = (a, b) => {
   }
   return (a <= b ? -1 : 1);
 };
+
+const inlineBlock = {
+ display: 'inline-block',
+ margin: '10px'
+};
+
 
 const Graphs = ({ benchmarkData, overviewMode }) => (
   <div>
@@ -34,9 +42,12 @@ const Graphs = ({ benchmarkData, overviewMode }) => (
         chartJsData, chartJsOptions, jointUrl, title,
       }) => (
         <div key={title}>
-          <h2>{title}</h2>
+          <h2 style={inlineBlock}>{title}</h2>
+          <div style={inlineBlock}>
+          <a href={jointUrl} target="_blank" rel="noopener noreferrer"><Link/></a>
+          </div>
           <ChartJSWrapper chartJsData={chartJsData} chartJsOptions={chartJsOptions} />
-          <a href={jointUrl} target="_blank" rel="noopener noreferrer">PerfHerder link</a>
+
         </div>
       ))}
   </div>


### PR DESCRIPTION
Hi @armenzg! I have added the material-ui link icon to the right-side of the benchmark title. Please check and provide feedback. 

![screenshot 18](https://user-images.githubusercontent.com/19373793/45976619-ee2d2a00-c064-11e8-875d-cd7be2444585.png)
