### PR TITLE
Upgrade to version 2.0.1 of perf-goggles

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@material-ui/core": "^3.0.2",
     "@material-ui/icons": "^3.0.1",
-    "@mozilla-frontend-infra/perf-goggles": "^2.0.0",
+    "@mozilla-frontend-infra/perf-goggles": "^2.0.1",
     "chart.js": "^2.7.2",
     "prop-types": "^15.6.2",
     "query-string": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,9 +129,9 @@
     "@babel/runtime" "7.0.0"
     recompose "^0.29.0"
 
-"@mozilla-frontend-infra/perf-goggles@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@mozilla-frontend-infra/perf-goggles/-/perf-goggles-2.0.0.tgz#96484488e9490b31797dc5838a2642534420acd3"
+"@mozilla-frontend-infra/perf-goggles@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@mozilla-frontend-infra/perf-goggles/-/perf-goggles-2.0.1.tgz#514bb39128beb07e29882849607d0efa90284fb8"
   dependencies:
     isomorphic-fetch "^2.2.1"
     lodash.isequal "^4.5.0"


### PR DESCRIPTION
There was an issue in the publishing of the previous version.